### PR TITLE
Updated Windows SDK to fix Tilengine Windows compilation under VC++

### DIFF
--- a/src/Tilengine.vcxproj
+++ b/src/Tilengine.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{9F321D8F-F164-4CAC-A45A-29A583C4F69D}</ProjectGuid>
     <RootNamespace>TilengineLib</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">


### PR DESCRIPTION
Using current Visual Studio 2017 requires to update Windows SDK to last version, would be nice to update.