### PR TITLE
Fix minor warnings and some other errors.

### DIFF
--- a/src/Animation.c
+++ b/src/Animation.c
@@ -107,6 +107,12 @@ void UpdateAnimations (int time)
 		case TYPE_TILESET:
 			TLN_CopyTile (engine->layers[animation->idx].tileset, frames[animation->pos].index, sequence->target);
 			break;
+
+		/* Fall through									*/
+		/* Stop warning GNU C compiler	*/
+		case TYPE_NONE:
+		case TYPE_PALETTE:
+			break;
 		}
 
 		/* next frame */

--- a/src/Base64.c
+++ b/src/Base64.c
@@ -17,9 +17,9 @@ static const unsigned char d[] =
 	66,66,66,66,66,66
 };
 
-int base64decode (const char* in, int inLen, unsigned char *out, int *outLen)
+int base64decode (const unsigned char* in, int inLen, unsigned char *out, int *outLen)
 {
-	const char* end = in + inLen;
+	const unsigned char* end = in + inLen;
 	int buf = 1, len = 0;
 
 	while (*in < 'A')

--- a/src/LoadBitmap.c
+++ b/src/LoadBitmap.c
@@ -95,7 +95,7 @@ static TLN_Bitmap LoadPNG (const char* filename)
 	png_byte color_type;
 	png_byte bit_depth;
 	png_bytep *row_pointers;
-	char header[8];
+	png_byte header[8];
 	int channels;
 	int y;
 

--- a/src/LoadFile.c
+++ b/src/LoadFile.c
@@ -44,6 +44,8 @@ void TLN_SetLoadPath (const char* path)
 	else
 		strncpy (localpath, ".", MAX_PATH);
 
+	localpath[MAX_PATH - 1] = '\0';
+
 	/* cut trailing separator */
 	trailing = strlen (localpath) - 1;
 	if (trailing > 0 && (localpath[trailing] == SLASH || localpath[trailing] == BACKSLASH))

--- a/src/LoadFile.c
+++ b/src/LoadFile.c
@@ -53,11 +53,11 @@ void TLN_SetLoadPath (const char* path)
 FILE* FileOpen (const char* filename)
 {
 	FILE* pf;
-	char path[255];
+	char path[MAX_PATH + 1];
 	char oldchar, newchar;
 	char* p;
 	
-	sprintf (path, "%s/%s", localpath, filename);
+	snprintf (path, sizeof(path), "%s/%s", localpath, filename);
 
 	/* replace correct path separator */
 	p = path;

--- a/src/LoadFile.c
+++ b/src/LoadFile.c
@@ -59,7 +59,11 @@ FILE* FileOpen (const char* filename)
 	char oldchar, newchar;
 	char* p;
 	
+#if (_MSC_VER) && (_MSC_VER < 1900)
+	sprintf (path, "%s/%s", localpath, filename);
+#else
 	snprintf (path, sizeof(path), "%s/%s", localpath, filename);
+#endif
 
 	/* replace correct path separator */
 	p = path;

--- a/src/LoadFile.c
+++ b/src/LoadFile.c
@@ -82,7 +82,7 @@ FILE* FileOpen (const char* filename)
 }
 
 /* generic load file into RAM buffer */
-uint8_t* LoadFile (const char* filename, size_t* out_size)
+uint8_t* LoadFile (const char* filename, ssize_t* out_size)
 {
 	size_t size;
 	FILE* pf;

--- a/src/LoadFile.h
+++ b/src/LoadFile.h
@@ -25,9 +25,14 @@
 
 /* win32 replacement for unix strcasecmp() */
 #if defined (_MSC_VER)
+#include <BaseTsd.h>
 #define strcasecmp _stricmp
+typedef SSIZE_T ssize_t;
 #else
 #include <strings.h>
+#ifdef __linux__
+#include <sys/types.h> // ssize_t
+#endif
 #endif
 
 uint8_t* LoadFile (const char* filename, ssize_t* out_size);

--- a/src/LoadFile.h
+++ b/src/LoadFile.h
@@ -30,7 +30,7 @@
 #include <strings.h>
 #endif
 
-uint8_t* LoadFile (const char* filename, size_t* out_size);
+uint8_t* LoadFile (const char* filename, ssize_t* out_size);
 FILE* FileOpen (const char* filename);
 bool CheckFile (const char* filename);
 

--- a/src/LoadSequencePack.c
+++ b/src/LoadSequencePack.c
@@ -185,7 +185,7 @@ TLN_SequencePack TLN_LoadSequencePack (const char* filename)
 	}
 
 	/* parse */
-	parser = simpleXmlCreateParser (data, (long)size);
+	parser = simpleXmlCreateParser ((char*)data, (long)size);
 	if (parser != NULL)
 	{
 		if (simpleXmlParse(parser, handler) != 0)

--- a/src/LoadSequencePack.c
+++ b/src/LoadSequencePack.c
@@ -162,7 +162,7 @@ static void* handler (SimpleXmlParser parser, SimpleXmlEvent evt,
 TLN_SequencePack TLN_LoadSequencePack (const char* filename)
 {
 	SimpleXmlParser parser;
-	size_t size;
+	ssize_t size;
 	uint8_t *data;
 
 	/* load file */

--- a/src/LoadSequencePack.c
+++ b/src/LoadSequencePack.c
@@ -61,7 +61,7 @@ static void* handler (SimpleXmlParser parser, SimpleXmlEvent evt,
 		if (!strcasecmp(szName, "sequence"))
 		{
 			if (!strcasecmp(szAttribute, "name"))
-				strncpy (loader.name, szValue, 16);
+				strncpy (loader.name, szValue, sizeof(loader.name));
 			else if (!strcasecmp(szAttribute, "delay"))
 				loader.delay = atoi(szValue);
 			else if (!strcasecmp(szAttribute, "first") || !strcasecmp(szAttribute, "target"))
@@ -72,7 +72,7 @@ static void* handler (SimpleXmlParser parser, SimpleXmlEvent evt,
 		else if (!strcasecmp(szName, "cycle"))
 		{
 			if (!strcasecmp(szAttribute, "name"))
-				strncpy (loader.name, szValue, 16);
+				strncpy (loader.name, szValue, sizeof(loader.name));
 		}
 		else if (!strcasecmp(szName, "strip"))
 		{
@@ -85,6 +85,9 @@ static void* handler (SimpleXmlParser parser, SimpleXmlEvent evt,
 			else if (!strcasecmp(szAttribute, "dir"))
 				loader.strips[loader.count].dir = (uint8_t)atoi(szValue);
 		}
+
+		loader.name[sizeof(loader.name) - 1] = '\0';
+
 		break;
 
 	case FINISH_ATTRIBUTES:

--- a/src/LoadTilemap.c
+++ b/src/LoadTilemap.c
@@ -207,7 +207,7 @@ static void* handler (SimpleXmlParser parser, SimpleXmlEvent evt,
 TLN_Tilemap TLN_LoadTilemap (const char *filename, const char *layername)
 {
 	SimpleXmlParser parser;
-	size_t size;
+	ssize_t size;
 	uint8_t *data;
 	
 	/* load file */

--- a/src/LoadTilemap.c
+++ b/src/LoadTilemap.c
@@ -225,7 +225,10 @@ TLN_Tilemap TLN_LoadTilemap (const char *filename, const char *layername)
 	memset (&loader, 0, sizeof(loader));
 	loader.tilemap = NULL;
 	if (layername)
-		strncpy (loader.layer_name, layername, 64);
+  {
+		strncpy (loader.layer_name, layername, sizeof(loader.layer_name));
+		loader.layer_name[sizeof(loader.layer_name) - 1] = '\0';
+  }
 	parser = simpleXmlCreateParser ((char*)data, (long)size);
 	if (parser != NULL)
 	{

--- a/src/LoadTilemap.c
+++ b/src/LoadTilemap.c
@@ -226,7 +226,7 @@ TLN_Tilemap TLN_LoadTilemap (const char *filename, const char *layername)
 	loader.tilemap = NULL;
 	if (layername)
 		strncpy (loader.layer_name, layername, 64);
-	parser = simpleXmlCreateParser (data, (long)size);
+	parser = simpleXmlCreateParser ((char*)data, (long)size);
 	if (parser != NULL)
 	{
 		if (simpleXmlParse(parser, handler) != 0)

--- a/src/LoadTilemap.c
+++ b/src/LoadTilemap.c
@@ -225,10 +225,10 @@ TLN_Tilemap TLN_LoadTilemap (const char *filename, const char *layername)
 	memset (&loader, 0, sizeof(loader));
 	loader.tilemap = NULL;
 	if (layername)
-  {
+	{
 		strncpy (loader.layer_name, layername, sizeof(loader.layer_name));
 		loader.layer_name[sizeof(loader.layer_name) - 1] = '\0';
-  }
+	}
 	parser = simpleXmlCreateParser ((char*)data, (long)size);
 	if (parser != NULL)
 	{

--- a/src/LoadTileset.c
+++ b/src/LoadTileset.c
@@ -89,7 +89,10 @@ static void* handler (SimpleXmlParser parser, SimpleXmlEvent evt,
 		else if (!strcasecmp(szName, "image"))
 		{
 			if (!strcasecmp(szAttribute, "source"))
-				strncpy (loader.source, szValue, 64);
+			{
+				strncpy (loader.source, szValue, sizeof(loader.source));
+				loader.source[sizeof(loader.source) - 1] = '\0';
+			}
 		}
 
 		/* <tile id="314"> */

--- a/src/LoadTileset.c
+++ b/src/LoadTileset.c
@@ -197,7 +197,7 @@ TLN_Tileset TLN_LoadTileset (const char* filename)
 
 	/* parse */
 	memset (&loader, 0, sizeof(loader));
-	parser = simpleXmlCreateParser (data, (long)size);
+	parser = simpleXmlCreateParser ((char*)data, (long)size);
 	if (parser != NULL)
 	{
 		if (simpleXmlParse(parser, handler) != 0)

--- a/src/LoadTileset.c
+++ b/src/LoadTileset.c
@@ -175,7 +175,7 @@ static void* handler (SimpleXmlParser parser, SimpleXmlEvent evt,
 TLN_Tileset TLN_LoadTileset (const char* filename)
 {
 	SimpleXmlParser parser;
-	size_t size;
+	ssize_t size;
 	uint8_t *data;
 	TLN_Tileset tileset;
 	TLN_Bitmap bitmap;

--- a/src/Sequence.c
+++ b/src/Sequence.c
@@ -117,7 +117,8 @@ TLN_Sequence TLN_CreateCycle (const char* name, int count, TLN_ColorStrip* strip
 	if (name)
 	{
 		sequence->hash = hash(0, name, strlen(name));
-		strncpy (sequence->name, name, 32);
+		strncpy (sequence->name, name, sizeof(sequence->name));
+		sequence->name[sizeof(sequence->name) - 1] = '\0';
 	}
 	
 	sequence->count = count;
@@ -184,7 +185,8 @@ bool TLN_GetSequenceInfo (TLN_Sequence sequence, TLN_SequenceInfo* info)
 {
 	if (CheckBaseObject (sequence, OT_SEQUENCE) && info != NULL)
 	{
-		strncpy (info->name, sequence->name, 32);
+		strncpy (info->name, sequence->name, sizeof(info->name));
+		info->name[sizeof(info->name) - 1] = '\0';
 		info->num_frames = sequence->count;
 		return true;
 	}

--- a/src/Sequence.c
+++ b/src/Sequence.c
@@ -68,7 +68,8 @@ TLN_Sequence TLN_CreateSequence (const char* name, int target, int count, TLN_Se
 	if (name)
 	{
 		sequence->hash = hash(0, name, strlen(name));
-		strncpy (sequence->name, name, 32);
+		strncpy (sequence->name, name, sizeof(sequence->name));
+		sequence->name[sizeof(sequence->name) - 1] = '\0';
 	}
 	sequence->target = target;
 	sequence->count = count;

--- a/src/Window.c
+++ b/src/Window.c
@@ -437,7 +437,10 @@ bool TLN_CreateWindow (const char* overlay, TLN_WindowFlags flags)
 	wnd_params.height = TLN_GetHeight ();
 	wnd_params.flags = flags|CWF_VSYNC;
 	if (overlay)
+	{
 		strncpy (wnd_params.file_overlay, overlay, MAX_PATH);
+		wnd_params.file_overlay[MAX_PATH - 1] = '\0';
+	}
 
 	ok = CreateWindow ();
 	if (ok)
@@ -490,7 +493,10 @@ bool TLN_CreateWindowThread (const char* overlay, TLN_WindowFlags flags)
 	wnd_params.height = TLN_GetHeight ();
 	wnd_params.flags = flags|CWF_VSYNC;
 	if (overlay)
+	{
 		strncpy (wnd_params.file_overlay, overlay, MAX_PATH);
+		wnd_params.file_overlay[MAX_PATH - 1] = '\0';
+	}
 
 	lock = SDL_CreateMutex ();
 	cond = SDL_CreateCond ();

--- a/src/Window.c
+++ b/src/Window.c
@@ -311,8 +311,8 @@ static void DeleteWindow (void)
 {
 	int c;
 
-    if (SDL_JoystickGetAttached(joy))
-        SDL_JoystickClose(joy);
+	if (SDL_JoystickGetAttached(joy))
+		SDL_JoystickClose(joy);
 
 	/* CRT effect resources */
 	SDL_DestroyTexture (crt.glow);


### PR DESCRIPTION
Muchos commits :smile: 
La idea es usar mucho el `cherry-pick` y aplicar sólo los cambios que estés de cuerdo.

El que necesita mas atención es: https://github.com/megamarc/Tilengine/commit/8979b251fd36b6e0cffba72df36de92226ea6f66 y todos los commits con descripción `Fix sign: use ssize_t..`
Explicación: `LoadFile` cuando genera un error indica `-1`, pero el parámetro es `size_t` que es `unsigned.` Lo ideal es usar `ssize_t` pero no se si es soportado por el compilador de MSC. Igualmente implemente una solución que encontré en la web, pero yo no tengo acceso a dicho compilador MSC, falta testear eso:https://github.com/megamarc/Tilengine/pull/40/commits/1f1e0344c8d45614fc7455a3bd799ce1c6a54b7c


