### PR TITLE
Exclude object file Test.o

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 CC       = gcc
-SOURCES  = $(wildcard *.c)
+SOURCES  = $(filter-out Test.c,$(wildcard *.c))
 OBJECTS  = $(SOURCES:.c=.o)
 INCPATH  = ../include
 


### PR DESCRIPTION
This file is linked to the shared library.

Note that this does not affect to make Test.