### PR TITLE
Makefile: allow overwrite some variables.

### DIFF
--- a/samples/Makefile
+++ b/samples/Makefile
@@ -1,8 +1,8 @@
-CC       = gcc
+CC       ?= gcc
 SOURCES  = $(wildcard *.c)
 OBJECTS  = $(SOURCES:.c=.o)
 TARGETS  = barrel mode7 platformer racer scaling shadow shooter tutorial wobble colorcycle benchmark supermarioclone test_mouse
-LIBPATH  = $(HOME)/Tilengine/lib
+LIBPATH  ?= $(HOME)/Tilengine/lib
 
 # Windows specific flags
 ifeq ($(OS),Windows_NT)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-CC       = gcc
+CC       ?= gcc
 SOURCES  = $(filter-out Test.c,$(wildcard *.c))
 OBJECTS  = $(SOURCES:.c=.o)
 INCPATH  = ../include


### PR DESCRIPTION
Este commit permite sobrescribir los valores por defecto de algunas variables del Makefile:
`CC`  para permitir elegir el compilador, por ejemplo, yo lo he testeado con Clang y TCC.
```bash
 CC=clang make
```
`LIBPATH` permite otra ubicación que `$(HOME)/Tilengine/lib`

```bash
 LIBPATH=../lib/linux_x86_64/  CC=clang make
```
Nota: El commit no tiene que ver con el issue #33