### PR TITLE
Fix enable/disable CRT effect: keyboard event.

### DIFF
--- a/src/Window.c
+++ b/src/Window.c
@@ -135,6 +135,7 @@ static void DeleteWindow (void);
 static void hblur (uint8_t* scan, int width, int height, int pitch);
 static void Downsample2 (uint8_t* src, uint8_t* dst, int width, int height, int src_pitch, int dst_pitch);
 static void BuildFullOverlay (SDL_Texture* texture, SDL_Surface* pattern, uint8_t factor);
+static void EnableCRTEffect (void);
 
 /* external prototypes */
 void GaussianBlur (uint8_t* src, uint8_t* dst, int width, int height, int pitch, int radius);
@@ -249,19 +250,7 @@ static bool CreateWindow(void)
 		crt.overlays[TLN_OVERLAY_CUSTOM] = SDL_LoadBMP(wnd_params.file_overlay);
 
 	/* enables CRT effect with last used parameters */
-	if (crt_enable)
-	{
-		TLN_EnableCRTEffect(crt_params.overlay,
-			crt_params.overlay_factor,
-			crt_params.threshold,
-			crt_params.v0,
-			crt_params.v1,
-			crt_params.v2,
-			crt_params.v3,
-			crt_params.blur,
-			crt_params.glow_factor
-		);
-	}
+	EnableCRTEffect();
 
 	/* temporal downsample surface */
 	resize_half_width = SDL_CreateRGBSurface(0, wnd_params.width / 2, wnd_params.height, 32, 0, 0, 0, 0);
@@ -662,7 +651,10 @@ bool TLN_ProcessWindow (void)
 				if (keybevt->keysym.sym == player_inputs[PLAYER1].keycodes[INPUT_QUIT])
 					done = true;
 				else if (keybevt->keysym.sym == player_inputs[PLAYER1].keycodes[INPUT_CRT])
+				{
 					crt_enable = !crt_enable;
+					EnableCRTEffect();
+				}
 				else if (keybevt->keysym.sym == SDLK_RETURN && keybevt->keysym.mod & KMOD_ALT)
 				{
 					DeleteWindow ();
@@ -846,6 +838,24 @@ void TLN_DisableCRTEffect (void)
 	crt_enable = false;
 }
 
+
+/* enables CRT effect with last used parameters */
+static void EnableCRTEffect (void)
+{
+	if (crt_enable)
+	{
+		TLN_EnableCRTEffect(crt_params.overlay,
+			crt_params.overlay_factor,
+			crt_params.threshold,
+			crt_params.v0,
+			crt_params.v1,
+			crt_params.v2,
+			crt_params.v3,
+			crt_params.blur,
+			crt_params.glow_factor
+		);
+	}
+}
 /*!
  * \brief
  * Returns the state of a given input


### PR DESCRIPTION
Make sure to call the `TLN_EnableCRTEffect` function by keyboard event as well, not only when the window is created.

Issue:
![tln_crt_fx](https://user-images.githubusercontent.com/46515895/54066710-cb668a80-422c-11e9-9536-133246355974.png)

Hola Marc!

Basicamente el problema esta en que la función  `TLN_EnableCRTEffect` sólo es efectiva cuando la ventana se crea por primera vez o por cambio a fullscreen.
https://github.com/megamarc/Tilengine/blob/54037fca5a29915685ade2a6bc7f8742a175a5e0/src/Window.c#L252
Entonces si antes de entrar a fullscreen se deshabilita el efecto mediante el teclado y, luego ya en fullscreen se la vuelve a habilitar, la función TLN_EnableCRTEffect nunca se llama.

Mi solución es crear una función local que pueda se llamada tanto cuando la ventana se inicia/reinicia y en el evento del teclado:
https://github.com/megamarc/Tilengine/blob/54037fca5a29915685ade2a6bc7f8742a175a5e0/src/Window.c#L664

Saludos.

