### PR TITLE
Language Bindings - Add RingTilengine

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ FreeBasic | [FBTilengine](https://github.com/megamarc/FBTilengine)
 Java	    | [JTilengine](https://github.com/megamarc/JTilengine)
 Rust      | [tilengine-sys](https://crates.io/crates/tilengine-sys)
 LuaJIT    | [tilengine_libretro](https://github.com/megamarc/Tilengine/tree/libretro) ([libretro](https://www.libretro.com) core)
+Ring      | [RingTilengine](https://github.com/ring-lang/ring/tree/master/extensions/ringtilengine)
 
 # Contributors
 These people contributed to tilengine:


### PR DESCRIPTION
RingTilengine is an extension for the Ring programming language that provide complete support for Tilengine
URL: https://github.com/ring-lang/ring/tree/master/extensions/ringtilengine
Starting from Ring 1.14, the Tilengine will be in the Ring standard library