### PR TITLE
Fix for access violation for the TLN_ERR_REF_LIST description.

### DIFF
--- a/src/Tilengine.c
+++ b/src/Tilengine.c
@@ -679,6 +679,7 @@ const char* const errornames[] =
 	"Resource file has invalid format",
 	"A width or height parameter is invalid",
 	"Unsupported function",
+	"Invalid ObjectList reference"
 };
 
 /*!


### PR DESCRIPTION
Fixed the access violation when `TLN_GetErrorString(TLN_ERR_REF_LIST)` is called. The exception is thrown because the description for TLN_ERR_REF_LIST did not exist.