### PR TITLE
Fix handling of unused tilesets in TLN_LoadTilemap

### DIFF
--- a/src/LoadTilemap.c
+++ b/src/LoadTilemap.c
@@ -217,40 +217,39 @@ TLN_Tilemap TLN_LoadTilemap (const char *filename, const char *layername)
 	{
 		Tile* tile;
 		uint32_t c;
+		TLN_Tileset tilesets[MAX_TILESETS] = { 0 }; /* list of tilesets */
+		bool used_tilesets[MAX_TILESETS] = { 0 };   /* set of used tilesets by index in Tiled */
+		int tileset_mapping[MAX_TILESETS] = { 0 };  /* mapping from index in Tiled to index in list */
 
-		/* build list of used tilesets */
-		bool _tilesets[MAX_TILESETS] = { 0 };
 		tile = (Tile*)loader.data;
 		for (c = 0; c < loader.numtiles; c += 1, tile += 1)
 		{
 			if (tile->index > 0)
 			{
 				int index = TMXGetSuitableTileset(&tmxinfo, tile->index);
-				_tilesets[index] = true;
+				used_tilesets[index] = true;
 			}
 		}
 
-		TLN_Tileset tilesets[MAX_TILESETS] = { 0 };
-		int used_tilesets[MAX_TILESETS] = { 0 };
 		uint32_t used_index = 0;
 		for (c = 0; c < MAX_TILESETS; c += 1)
 		{
-			if (_tilesets[c])
+			if (used_tilesets[c])
 			{
 				tilesets[used_index] = load_tileset(&tmxinfo, filename, c);
-				used_tilesets[used_index] = c;
+				tileset_mapping[c] = used_index;
 				used_index += 1;
 			}
 		}
 
-		/* TODO correct with firstgid */
 		tile = (Tile*)loader.data;
 		for (c = 0; c < loader.numtiles; c += 1, tile += 1)
 		{
 			if (tile->index > 0)
 			{
-				tile->tileset = TMXGetSuitableTileset(&tmxinfo, tile->index);
-				tile->index = tile->index - tmxinfo.tilesets[tile->tileset].firstgid + 1;
+				int index = TMXGetSuitableTileset(&tmxinfo, tile->index);
+				tile->tileset = tileset_mapping[index];
+				tile->index = tile->index - tmxinfo.tilesets[index].firstgid + 1;
 			}
 		}
 


### PR DESCRIPTION
This PR fixes a problem when loading maps whose Tiled layer doesn't use every tileset in the .tmx file.

The unused tilesets would be correctly omitted from the resulting `TLN_Tilemap`, causing the indexes of later tilesets to move down. But, the tiles in the map would still be referring to the old indexes, as if no tilesets had been omitted. This caused segfaults during rendering.

I introduced a mapping from old index to new index and used this to correct the tiles, which seems to have fixed the problem.

_Side note: Trying to use the broken tilemap leads to `TLN_SetLayer` skipping initialisation due to [this check](https://github.com/megamarc/Tilengine/blob/9f2838369756238e65b0b4302a7aa8514b2beb61/src/Layer.c#L66). I'm not entirely sure the check is correct since it only deals with `tilemap->tilesets[0]`, so you might want to take a look at it._