### PR TITLE
Fixed out of bounds when accessing variable

### DIFF
--- a/src/Tilengine.c
+++ b/src/Tilengine.c
@@ -800,7 +800,8 @@ const char* const errornames[] =
 	"Resource file has invalid format",
 	"A width or height parameter is invalid",
 	"Unsupported function",
-	"Invalid ObjectList reference"
+	"Invalid ObjectList reference",
+	"Palette index out of range"
 };
 
 /*!


### PR DESCRIPTION
When the variable `errornames[]` is accessed by calling `TLN_SetLastError(TLN_ERR_IDX_PALETTE)`

Similar reference: #94 
